### PR TITLE
Extraction failures for file names with special characters

### DIFF
--- a/src/contentBase.ts
+++ b/src/contentBase.ts
@@ -65,7 +65,7 @@ export class ContentBase {
                 zipfile.readEntry();
                 zipfile.on("entry", (entry) => {
                     // fix path direction if there are any issues before validating
-                    const validName = this.validateFilename(fileList, entry);
+                    let validName = this.validateAndDecodeFilename(fileList, entry);
                     var valuable = searchStrings.some(file => validName.toLowerCase().includes(file));
                     if (valuable) {
                         entry.fileName = validName;
@@ -121,8 +121,9 @@ export class ContentBase {
     // The zip extractor tool (yauzl) throws if the file path includes \, 
     // however in windows this is a common scenario, so before validating the file name, 
     // we replace \ with path.sep" to stop fileName validation from failing
-     private validateFilename(fileList: string[], entry: any) : string {
+     private validateAndDecodeFilename(fileList: string[], entry: any) : string {
         let validName = entry.fileName.toString().split('\\').join(path.sep);
+        validName = decodeURI(validName);
         const errorMessage = yauzl.validateFileName(validName);
         if (errorMessage != null) {
             throw new ExtractError("unzip filename validation failed");


### PR DESCRIPTION
File names that had special characters failed to be extracted. 

Reason: after unzipping the package, the file names in the package were encoded. 
`findFile` method was failing because it was looking for the decoded version of the file.

**original**: fileName (example).appxbundle 
**after unzipping**:  fileName%20%28example%29.appxbundle 
**after the fix**: fileName (example).appxbundle