### PR TITLE
Adjust the device family field of the ipa file.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "app-metadata",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-metadata",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "This library provides functionality to extract IPA, APK and UWP packages.",
   "main": "./index.js",
   "repository": {

--- a/src/ipaContent.ts
+++ b/src/ipaContent.ts
@@ -115,12 +115,15 @@ export class IpaContent extends ContentBase implements IIPAMetadata {
         this.minimumOsVersion = plistData.MinimumOSVersion || plistData.LSMinimumSystemVersion;
         if (plistData.UIDeviceFamily) {
             if (plistData.UIDeviceFamily.length === 1) {
-                this.deviceFamily = "iPhone/iPod";
+                let deviceValue = plistData.UIDeviceFamily[0];
+                if (deviceValue === 1) {
+                    this.deviceFamily = "iPhone/iPod";                
+                } else if ( deviceValue === 2) {
+                    this.deviceFamily = "iPad";
+                }
             } else if (plistData.UIDeviceFamily.length === 2) {
-                this.deviceFamily = "iPhone/iPod/iPad";
+                this.deviceFamily = "iPhone/iPod/iPad"; 
             }
-        } else {
-            this.deviceFamily = "iOS";
         }
     }
     private async parseProvision(provision: ProvisioningProfile, provisionName: string, tempDir: string, fileList: any): Promise<any> {


### PR DESCRIPTION
This PR re-fixed the previous issue on the device family fields. Details refers to [UIDeviceFamily](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html) iOS Key.